### PR TITLE
Fix disabled button when no CSV files found

### DIFF
--- a/FTIR_V11.py
+++ b/FTIR_V11.py
@@ -347,6 +347,8 @@ def combine_time_resolved_csv_to_csv():
                  if f.lower().endswith('.csv') and "static" not in f.lower()]
     if not csv_files:
         messagebox.showerror("Error", "No suitable CSV files found.", parent=window)
+        status_label.config(text="Completed", fg="green")
+        time_resolved_csv_button.config(state=tk.NORMAL)
         return
 
     combined_df = None


### PR DESCRIPTION
## Summary
- re-enable time-resolved CSV button when no files are available
- update status label in that case

## Testing
- `python -m py_compile FTIR_V11.py`
- `python -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_684971168cfc8332aa776b3a80a153b8